### PR TITLE
Gz tree

### DIFF
--- a/cnn/datasets.py
+++ b/cnn/datasets.py
@@ -26,6 +26,16 @@ for dset_name_norm, dset_alias_list in VALID_DSET_NAMES.items():
     for dset_alias_name in dset_alias_list:
         DSET_NAME_TBL[dset_alias_name] = dset_name_norm
 
+# Default batch size for known data sets
+BATCH_SIZE_TBL = {
+    'CIFAR': 96,
+    'MNIST': 96,
+    'FashionMNIST': 96,
+    'GrapheneKirigami': 96,
+    'GalaxyZoo': 40,
+}
+
+# AWS storage bucket
 BUCKET_NAME = 'capstone2019-google'
 
 # *****************************************************************************

--- a/cnn/datasets.py
+++ b/cnn/datasets.py
@@ -20,6 +20,12 @@ VALID_DSET_NAMES = {
     'GalaxyZoo': ['galaxy-zoo', 'galaxyzoo']
 }
 
+# Table to normalize data set name; key = aliased name, value = canonical dataset name
+DSET_NAME_TBL = dict()
+for dset_name_norm, dset_alias_list in VALID_DSET_NAMES.items():
+    for dset_alias_name in dset_alias_list:
+        DSET_NAME_TBL[dset_alias_name] = dset_name_norm
+
 BUCKET_NAME = 'capstone2019-google'
 
 # *****************************************************************************

--- a/cnn/datasets.py
+++ b/cnn/datasets.py
@@ -26,15 +26,6 @@ for dset_name_norm, dset_alias_list in VALID_DSET_NAMES.items():
     for dset_alias_name in dset_alias_list:
         DSET_NAME_TBL[dset_alias_name] = dset_name_norm
 
-# Default batch size for known data sets
-BATCH_SIZE_TBL = {
-    'CIFAR': 96,
-    'MNIST': 96,
-    'FashionMNIST': 96,
-    'GrapheneKirigami': 96,
-    'GalaxyZoo': 40,
-}
-
 # AWS storage bucket
 BUCKET_NAME = 'capstone2019-google'
 
@@ -116,14 +107,17 @@ def load_dataset(args, train=True):
         # the locations of the images and CSV label files for train and test
         train_img_dir = os.path.join(data_path, 'images_train')
         train_csv_file = os.path.join(data_path, 'labels_train/labels_train.csv')
+        # for test data, only images available; the labels are NOT ground truth, just a placeholder!
         test_img_dir = os.path.join(data_path, 'images_test')
-        test_csv_file = os.path.join(data_path, 'benchmark_solutions/central_pirxel_benchmark.csv')
+        test_csv_file = os.path.join(data_path, 'benchmark_solutions/central_pixel_benchmark.csv')
         # choose appropriate image directory and CSV file
-        img_dir = train_img_dir if train else test_img_dir
-        csv_file = train_csv_file if train else test_csv_file
+        csv_file = train_csv_file if train else val_csv_file
         # instantiate the Dataset
-        data = DatasetGalaxyZoo(train_img_dir, train_csv_file, transform=transform)
-        # TODO add logic to fill in 37 classifiers from 11 decision tree outputs
+        if train:
+            data = DatasetGalaxyZoo(train_img_dir, train_csv_file, transform=transform)
+        else:
+            data = DatasetGalaxyZoo(test_img_dir, test_csv_file, transform=transform)
+        # these parameters don't depend on train vs. validation
         output_dim = 37
         in_channels = 3
         is_regression = True

--- a/cnn/genotypes.py
+++ b/cnn/genotypes.py
@@ -26,6 +26,19 @@ PRIMITIVES = [
     'dil_conv_5x5'
 ]
 
+PRIMITIVES_GZ = [
+    'none',
+    'skip_connect',
+    'max_pool_2x2',
+    # 'avg_pool_2x2',
+    'max_pool_3x3',
+    'avg_pool_3x3',
+    'sep_conv_3x3',
+    'sep_conv_5x5',
+    'dil_conv_3x3',
+    'dil_conv_5x5'
+]
+
 NASNet = Genotype(
   normal = [
     ('sep_conv_5x5', 1),

--- a/cnn/genotypes.py
+++ b/cnn/genotypes.py
@@ -190,11 +190,27 @@ GRAPHENE = Genotype(
 	('sep_conv_3x3', 2)], 
 	reduce_concat=range(2, 6))
     
-# Best discovered architecture for GalaxyZoo 2019-11-03
-# 2019-11-04 00:26:47,645 validation loss; R2: 9.110350e-03
+# Best discovered architecture for GalaxyZoo 2019-11-05
+# 2019-11-05 09:18:10,861 validation loss; R2: 8.993143e-03 -0.243955
 GALAXY_ZOO = Genotype(
-    normal=[('max_pool_2x2', 0), ('max_pool_2x2', 1), ('max_pool_2x2', 2), ('max_pool_2x2', 0), ('max_pool_3x3', 0), ('sep_conv_5x5', 3), ('dil_conv_5x5', 4), ('max_pool_3x3', 1)], normal_concat=range(2, 6), 
-    reduce=[('max_pool_3x3', 1), ('max_pool_3x3', 0), ('sep_conv_5x5', 0), ('dil_conv_5x5', 2), ('dil_conv_5x5', 3), ('dil_conv_5x5', 2), ('dil_conv_5x5', 2), ('dil_conv_5x5', 4)], reduce_concat=range(2, 6))
+    normal=[('dil_conv_3x3', 0), 
+            ('dil_conv_5x5', 1), 
+            ('dil_conv_5x5', 2), 
+            ('max_pool_2x2', 0), 
+            ('dil_conv_5x5', 0), 
+            ('sep_conv_5x5', 2), 
+            ('sep_conv_5x5', 4), 
+            ('max_pool_3x3', 1)], 
+            normal_concat=range(2, 6), 
+    reduce=[('max_pool_3x3', 0), 
+            ('max_pool_3x3', 1), 
+            ('max_pool_3x3', 0), 
+            ('dil_conv_5x5', 2), 
+            ('dil_conv_5x5', 2), 
+            ('dil_conv_5x5', 3), 
+            ('dil_conv_5x5', 4), 
+            ('dil_conv_5x5', 0)], 
+            reduce_concat=range(2, 6))
 
 # Table of default architecture by standardized data set name
 GENOTYPE_TBL = {

--- a/cnn/genotypes.py
+++ b/cnn/genotypes.py
@@ -189,3 +189,17 @@ GRAPHENE = Genotype(
 	('sep_conv_5x5', 4), 
 	('sep_conv_3x3', 2)], 
 	reduce_concat=range(2, 6))
+    
+# Interim architecture for GalaxyZoo 2019-11-03
+GALAXY_ZOO = Genotype(
+    normal=[('max_pool_3x3', 0), ('dil_conv_5x5', 1), ('max_pool_3x3', 0), ('dil_conv_5x5', 2), ('max_pool_3x3', 0), ('dil_conv_5x5', 3), ('sep_conv_3x3', 3), ('max_pool_3x3', 0)], normal_concat=range(2, 6), 
+    reduce=[('max_pool_3x3', 1), ('max_pool_3x3', 0), ('max_pool_3x3', 0), ('max_pool_3x3', 2), ('dil_conv_5x5', 3), ('dil_conv_5x5', 2), ('max_pool_3x3', 2), ('sep_conv_3x3', 0)], reduce_concat=range(2, 6))    
+
+# Table of default architecture by standardized data set name
+GENOTYPE_TBL = {
+    'CIFAR': CIFAR_10,
+    'MNIST': MNIST,
+    'FashionMNIST': FASHION_MNIST,
+    'GrapheneKirigami': GRAPHENE,
+    'GalaxyZoo': GALAXY_ZOO,
+}

--- a/cnn/genotypes.py
+++ b/cnn/genotypes.py
@@ -15,7 +15,8 @@ def load_genotype_from_file(filename):
     return eval(f.readline().strip())
 
 
-PRIMITIVES = [
+# Default set of primitives
+primitives_Default = [
     'none',
     'max_pool_3x3',
     'avg_pool_3x3',
@@ -26,7 +27,8 @@ PRIMITIVES = [
     'dil_conv_5x5'
 ]
 
-PRIMITIVES_GZ = [
+# Primitives for Galaxy Zoo data set
+primitives_GalaxyZoo = [
     'none',
     'skip_connect',
     'max_pool_2x2',
@@ -38,6 +40,16 @@ PRIMITIVES_GZ = [
     'dil_conv_3x3',
     'dil_conv_5x5'
 ]
+
+# Dictionary of primitive sets
+PRIMITIVES_TBL = {
+    'Default': primitives_Default,
+    'CIFAR': primitives_Default,
+    'MNIST': primitives_Default,
+    'FashionMNIST': primitives_Default,
+    'GrapheneKirigami': primitives_Default,
+    'GalaxyZoo': primitives_GalaxyZoo
+}
 
 NASNet = Genotype(
   normal = [

--- a/cnn/genotypes.py
+++ b/cnn/genotypes.py
@@ -190,10 +190,11 @@ GRAPHENE = Genotype(
 	('sep_conv_3x3', 2)], 
 	reduce_concat=range(2, 6))
     
-# Interim architecture for GalaxyZoo 2019-11-03
+# Best discovered architecture for GalaxyZoo 2019-11-03
+# 2019-11-04 00:26:47,645 validation loss; R2: 9.110350e-03
 GALAXY_ZOO = Genotype(
-    normal=[('max_pool_3x3', 0), ('dil_conv_5x5', 1), ('max_pool_3x3', 0), ('dil_conv_5x5', 2), ('max_pool_3x3', 0), ('dil_conv_5x5', 3), ('sep_conv_3x3', 3), ('max_pool_3x3', 0)], normal_concat=range(2, 6), 
-    reduce=[('max_pool_3x3', 1), ('max_pool_3x3', 0), ('max_pool_3x3', 0), ('max_pool_3x3', 2), ('dil_conv_5x5', 3), ('dil_conv_5x5', 2), ('max_pool_3x3', 2), ('sep_conv_3x3', 0)], reduce_concat=range(2, 6))    
+    normal=[('max_pool_2x2', 0), ('max_pool_2x2', 1), ('max_pool_2x2', 2), ('max_pool_2x2', 0), ('max_pool_3x3', 0), ('sep_conv_5x5', 3), ('dil_conv_5x5', 4), ('max_pool_3x3', 1)], normal_concat=range(2, 6), 
+    reduce=[('max_pool_3x3', 1), ('max_pool_3x3', 0), ('sep_conv_5x5', 0), ('dil_conv_5x5', 2), ('dil_conv_5x5', 3), ('dil_conv_5x5', 2), ('dil_conv_5x5', 2), ('dil_conv_5x5', 4)], reduce_concat=range(2, 6))
 
 # Table of default architecture by standardized data set name
 GENOTYPE_TBL = {

--- a/cnn/model.py
+++ b/cnn/model.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from operations import *
 from torch.autograd import Variable
 from utils import drop_path
@@ -9,7 +10,6 @@ class Cell(nn.Module):
 
   def __init__(self, genotype, C_prev_prev, C_prev, C, reduction, reduction_prev):
     super(Cell, self).__init__()
-    print(C_prev_prev, C_prev, C)
 
     if reduction_prev:
       self.preprocess0 = FactorizedReduce(C_prev_prev, C)
@@ -213,3 +213,153 @@ class NetworkImageNet(nn.Module):
     out = self.global_pooling(s1)
     logits = self.classifier(out.view(out.size(0), -1))
     return logits, logits_aux
+
+
+class NetworkGalaxyZoo(nn.Module):
+
+  def __init__(self, C, num_classes, layers, genotype, fc1_size: int, fc2_size: int, num_channels=3):
+    super(NetworkGalaxyZoo, self).__init__()
+    self._layers = layers
+    self._num_channels = num_channels
+
+    stem_multiplier = 3
+    C_curr = stem_multiplier*C
+    self.stem = nn.Sequential(
+      nn.Conv2d(self._num_channels, C_curr, 3, padding=1, bias=False),
+      nn.BatchNorm2d(C_curr)
+    )
+
+    C_prev_prev, C_prev, C_curr = C_curr, C_curr, C
+    self.cells = nn.ModuleList()
+    reduction_prev = False
+    for i in range(layers):
+      if i in [layers//3, 2*layers//3]:
+        C_curr *= 2
+        reduction = True
+      else:
+        reduction = False
+      cell = Cell(genotype, C_prev_prev, C_prev, C_curr, reduction, reduction_prev)
+      reduction_prev = reduction
+      self.cells += [cell]
+      C_prev_prev, C_prev = C_prev, cell.multiplier*C_curr
+
+    self.global_pooling = nn.AdaptiveAvgPool2d(1)
+
+    # Fully connected layers
+    self.num_fc_layers = 2 if fc2_size > 0 else 1
+    self.fc1 = nn.Linear(C_prev, fc1_size)
+    if self.num_fc_layers >= 2:
+        self.fc2 = nn.Linear(fc1_size, fc2_size)
+    fc_last_size = fc2_size if self.num_fc_layers == 2 else fc1_size
+
+    # Galaxy Zoo question 1: smooth galaxy; galaxy with features or disk; elliptic
+    self.classifier_q1 = nn.Linear(fc_last_size, 3)
+
+    # Galaxy Zoo question 2: Is it edge on?
+    self.classifier_q2 = nn.Linear(fc_last_size, 2)
+
+    # Galaxy Zoo question 3: Is there a bar?
+    self.classifier_q3 = nn.Linear(fc_last_size, 2)
+
+    # Galaxy Zoo question 4: Is there a spiral pattern?
+    self.classifier_q4 = nn.Linear(fc_last_size, 2)
+
+    # Galaxy Zoo question 5: How prominent is the central bulge?
+    self.classifier_q5 = nn.Linear(fc_last_size, 4)
+
+    # Galaxy Zoo question 6: Is there anything odd?
+    self.classifier_q6 = nn.Linear(fc_last_size, 2)
+
+    # Galaxy Zoo question 7: How rounded is it?
+    self.classifier_q7 = nn.Linear(fc_last_size, 3)
+
+    # Galaxy Zoo question 8: What is the odd feature?
+    self.classifier_q8 = nn.Linear(fc_last_size, 7)
+
+    # Galaxy Zoo question 9: Is Does the galaxy have a bulge?
+    self.classifier_q9 = nn.Linear(fc_last_size, 3)
+
+    # Galaxy Zoo question 10: How tightly wound is it?
+    self.classifier_q10 = nn.Linear(fc_last_size, 3)
+
+    # Galaxy Zoo question 11: How many spiral arms?
+    self.classifier_q11 = nn.Linear(fc_last_size, 6)
+
+  def forward(self, input):
+    logits_aux = None
+    s0 = s1 = self.stem(input)
+    for i, cell in enumerate(self.cells):
+      s0, s1 = s1, cell(s0, s1, self.drop_path_prob)
+    out = self.global_pooling(s1)
+
+    # Fully connected layers
+    conv_out = out.view(out.size(0),-1)
+    fc1_out = self.fc1(conv_out)
+    if self.num_fc_layers >= 2:
+        fc2_out = self.fc2(fc1_out)
+        fc_out = fc2_out
+    else:
+        fc_out = fc1_out
+        
+    # Logits for classifiers on GalaxyZoo questions
+    logits_q1 = self.classifier_q1(fc_out)
+    logits_q2 = self.classifier_q2(fc_out)
+    logits_q3 = self.classifier_q3(fc_out)
+    logits_q4 = self.classifier_q4(fc_out)
+    logits_q5 = self.classifier_q5(fc_out)
+    logits_q6 = self.classifier_q6(fc_out)
+    logits_q7 = self.classifier_q7(fc_out)
+    logits_q8 = self.classifier_q8(fc_out)
+    logits_q9 = self.classifier_q9(fc_out)
+    logits_q10 = self.classifier_q10(fc_out)
+    logits_q11 = self.classifier_q11(fc_out)
+
+    # Classification probabilities for GalaxyZoo questions
+    # Each output is a product of (probability classification is relevant) x (conditional probabilities)
+    # A1 = C1
+    probs_q1 = F.softmax(logits_q1, dim=-1)
+    C1_1 = probs_q1[:,0:1]
+    C1_2 = probs_q1[:,1:2]
+
+    # A2 = C1.2 * C2
+    probs_q2 = C1_2 * F.softmax(logits_q2, dim=-1)
+    C2_1 = probs_q2[:,0:1]
+    C2_2 = probs_q2[:,1:2]
+
+    # A3 = C2.2 * C3
+    probs_q3 = C2_2 * F.softmax(logits_q3, dim=-1)
+
+    # A4 = C2.2 * C4
+    probs_q4 = C2_2 * F.softmax(logits_q4, dim=-1)
+    C4_1 = probs_q4[:,0:1]
+
+    # A5 = C2.2 * C5
+    probs_q5 = C2_2 * F.softmax(logits_q5, dim=-1)
+
+    # A6 = C6
+    probs_q6 = F.softmax(logits_q6, dim=-1)
+    C6_1 = probs_q1[:,0:1]
+
+    # A7 = C1.1 * C7
+    probs_q7 = C1_1 * F.softmax(logits_q7, dim=-1)
+
+    # A8 = C6.1 * C8
+    probs_q8 = C6_1 * F.softmax(logits_q8, dim=-1)
+
+    # A9 = C2.1 * C9
+    probs_q9 = C2_1 * F.softmax(logits_q9, dim=-1)
+
+    # A10 = C4.1 * C10
+    probs_q10 = C4_1 * F.softmax(logits_q10, dim=-1)
+
+    # A11 = C4.1 * C10
+    probs_q11 = C4_1 * F.softmax(logits_q11, dim=-1)
+
+    # Concatenate probabilities into vector of length 37
+    probs = torch.cat([probs_q1, probs_q2, probs_q3, probs_q4, probs_q5, probs_q6, 
+                       probs_q7, probs_q8, probs_q9, probs_q10, probs_q11], dim=-1)
+
+    # No auxiliary outputs for this model; include for API consistency
+    probs_aux = None
+    return probs, probs_aux
+

--- a/cnn/model_search.py
+++ b/cnn/model_search.py
@@ -199,39 +199,47 @@ class NetworkGalaxyZoo(Network):
       C_prev_prev, C_prev = C_prev, multiplier*C_curr
 
     self.global_pooling = nn.AdaptiveAvgPool2d(1)
+    
+    # Fully connected layers
+    fc1_size = 1024
+    # print(f'type(C_prev) = {type(C_prev)}')
+    self.fc1 = nn.Linear(C_prev, fc1_size)
+    # print(f'type(fc1) = {type(self.fc1)}')
+    # fc2_size = 256
+    # self.fc2 = nn.Linear(fc1_size, fc2_size)
 
     # Galaxy Zoo question 1: smooth galaxy; galaxy with features or disk; elliptic
-    self.classifier_q1 = nn.Linear(C_prev, 3)
+    self.classifier_q1 = nn.Linear(fc1_size, 3)
 
     # Galaxy Zoo question 2: Is it edge on?
-    self.classifier_q2 = nn.Linear(C_prev, 2)
+    self.classifier_q2 = nn.Linear(fc1_size, 2)
 
     # Galaxy Zoo question 3: Is there a bar?
-    self.classifier_q3 = nn.Linear(C_prev, 2)
+    self.classifier_q3 = nn.Linear(fc1_size, 2)
 
     # Galaxy Zoo question 4: Is there a spiral pattern?
-    self.classifier_q4 = nn.Linear(C_prev, 2)
+    self.classifier_q4 = nn.Linear(fc1_size, 2)
 
     # Galaxy Zoo question 5: How prominent is the central bulge?
-    self.classifier_q5 = nn.Linear(C_prev, 4)
+    self.classifier_q5 = nn.Linear(fc1_size, 4)
 
     # Galaxy Zoo question 6: Is there anything odd?
-    self.classifier_q6 = nn.Linear(C_prev, 2)
+    self.classifier_q6 = nn.Linear(fc1_size, 2)
 
     # Galaxy Zoo question 7: How rounded is it?
-    self.classifier_q7 = nn.Linear(C_prev, 3)
+    self.classifier_q7 = nn.Linear(fc1_size, 3)
 
     # Galaxy Zoo question 8: What is the odd feature?
-    self.classifier_q8 = nn.Linear(C_prev, 7)
+    self.classifier_q8 = nn.Linear(fc1_size, 7)
 
     # Galaxy Zoo question 9: Is Does the galaxy have a bulge?
-    self.classifier_q9 = nn.Linear(C_prev, 3)
+    self.classifier_q9 = nn.Linear(fc1_size, 3)
 
     # Galaxy Zoo question 10: How tightly wound is it?
-    self.classifier_q10 = nn.Linear(C_prev, 3)
+    self.classifier_q10 = nn.Linear(fc1_size, 3)
 
     # Galaxy Zoo question 11: How many spiral arms?
-    self.classifier_q11 = nn.Linear(C_prev, 6)
+    self.classifier_q11 = nn.Linear(fc1_size, 6)
 
     # initialize edge weights
     self._initialize_alphas()
@@ -255,19 +263,23 @@ class NetworkGalaxyZoo(Network):
         weights = F.softmax(self.alphas_normal, dim=-1)
       s0, s1 = s1, cell(s0, s1, weights)
     out = self.global_pooling(s1)
+    
+    # Fully connected layers
+    out_fc1 = self.fc1(out.view(out.size(0),-1))
+    # out_fc2 = self.fc1(out.view(out.size(0),-1))
 
     # Logits for classifiers on GalaxyZoo questions
-    logits_q1 = self.classifier_q1(out.view(out.size(0),-1))
-    logits_q2 = self.classifier_q2(out.view(out.size(0),-1))
-    logits_q3 = self.classifier_q3(out.view(out.size(0),-1))
-    logits_q4 = self.classifier_q4(out.view(out.size(0),-1))
-    logits_q5 = self.classifier_q5(out.view(out.size(0),-1))
-    logits_q6 = self.classifier_q6(out.view(out.size(0),-1))
-    logits_q7 = self.classifier_q7(out.view(out.size(0),-1))
-    logits_q8 = self.classifier_q8(out.view(out.size(0),-1))
-    logits_q9 = self.classifier_q9(out.view(out.size(0),-1))
-    logits_q10 = self.classifier_q10(out.view(out.size(0),-1))
-    logits_q11 = self.classifier_q11(out.view(out.size(0),-1))
+    logits_q1 = self.classifier_q1(out_fc1)
+    logits_q2 = self.classifier_q2(out_fc1)
+    logits_q3 = self.classifier_q3(out_fc1)
+    logits_q4 = self.classifier_q4(out_fc1)
+    logits_q5 = self.classifier_q5(out_fc1)
+    logits_q6 = self.classifier_q6(out_fc1)
+    logits_q7 = self.classifier_q7(out_fc1)
+    logits_q8 = self.classifier_q8(out_fc1)
+    logits_q9 = self.classifier_q9(out_fc1)
+    logits_q10 = self.classifier_q10(out_fc1)
+    logits_q11 = self.classifier_q11(out_fc1)
 
     # Classification probabilities for GalaxyZoo questions
     # Each output is a product of (probability classification is relevant) x (conditional probabilities)

--- a/cnn/model_search.py
+++ b/cnn/model_search.py
@@ -175,7 +175,7 @@ class NetworkGalaxyZoo(Network):
   """Subclass of Network specialized for the GalaxyZoo problem"""
 
   def __init__(self, primitives_name: str, C, num_classes, layers, criterion, 
-               num_channels=3, steps=4, multiplier=4, stem_multiplier=3):
+               fc1_size: int, fc2_size: int, num_channels=3, steps=4, multiplier=4, stem_multiplier=3):
     # super(Network, self).__init__()
     # Network.__init__(self, C=C, num_classes=num_classes, layers=layers, primitives_name=primitives_name,
     #                 criterion=criterion, num_channels=num_channels)
@@ -215,8 +215,6 @@ class NetworkGalaxyZoo(Network):
     self.global_pooling = nn.AdaptiveAvgPool2d(1)
     
     # Fully connected layers
-    fc1_size = 1024
-    fc2_size = 1024
     self.fc1 = nn.Linear(C_prev, fc1_size)
     self.fc2 = nn.Linear(fc1_size, fc2_size)
     fc_last_size = fc1_size

--- a/cnn/operations.py
+++ b/cnn/operations.py
@@ -3,14 +3,21 @@ import torch.nn as nn
 
 OPS = {
   'none' : lambda C, stride, affine: Zero(stride),
-  'avg_pool_3x3' : lambda C, stride, affine: nn.AvgPool2d(3, stride=stride, padding=1, count_include_pad=False),
-  'max_pool_3x3' : lambda C, stride, affine: nn.MaxPool2d(3, stride=stride, padding=1),
   'skip_connect' : lambda C, stride, affine: Identity() if stride == 1 else FactorizedReduce(C, C, affine=affine),
-  'sep_conv_3x3' : lambda C, stride, affine: SepConv(C, C, 3, stride, 1, affine=affine),
-  'sep_conv_5x5' : lambda C, stride, affine: SepConv(C, C, 5, stride, 2, affine=affine),
-  'sep_conv_7x7' : lambda C, stride, affine: SepConv(C, C, 7, stride, 3, affine=affine),
-  'dil_conv_3x3' : lambda C, stride, affine: DilConv(C, C, 3, stride, 2, 2, affine=affine),
-  'dil_conv_5x5' : lambda C, stride, affine: DilConv(C, C, 5, stride, 4, 2, affine=affine),
+  'max_pool_2x2' : lambda C, stride, affine: nn.Sequential(
+    nn.ZeroPad2d((0,1,0,1)),
+    nn.MaxPool2d(kernel_size=2, stride=stride, padding=0)
+    ),
+  'max_pool_3x3' : lambda C, stride, affine: nn.MaxPool2d(kernel_size=3, stride=stride, padding=1),
+  'avg_pool_2x2' : lambda C, stride, affine: nn.Sequential(
+    nn.ZeroPad2d((0,1,0,1)),
+    nn.AvgPool2d(kernel_size=2, stride=stride, padding=0, count_include_pad=False)),
+  'avg_pool_3x3' : lambda C, stride, affine: nn.AvgPool2d(kernel_size=3, stride=stride, padding=1, count_include_pad=False),
+  'sep_conv_3x3' : lambda C, stride, affine: SepConv(C, C, kernel_size=3, stride=stride, padding=1, affine=affine),
+  'sep_conv_5x5' : lambda C, stride, affine: SepConv(C, C, kernel_size=5, stride=stride, padding=2, affine=affine),
+  'sep_conv_7x7' : lambda C, stride, affine: SepConv(C, C, kernel_size=7, stride=stride, padding=3, affine=affine),  
+  'dil_conv_3x3' : lambda C, stride, affine: DilConv(C, C, kernel_size=3, stride=stride, padding=2, dilation=2, affine=affine),
+  'dil_conv_5x5' : lambda C, stride, affine: DilConv(C, C, kernel_size=5, stride=stride, padding=4, dilation=2, affine=affine),
   'conv_7x1_1x7' : lambda C, stride, affine: nn.Sequential(
     nn.ReLU(inplace=False),
     nn.Conv2d(C, C, (1,7), stride=(1, stride), padding=(0, 3), bias=False),

--- a/cnn/train.py
+++ b/cnn/train.py
@@ -16,15 +16,15 @@ import torch.backends.cudnn as cudnn
 from torch.autograd import Variable
 from model import NetworkCIFAR, NetworkGalaxyZoo
 from model_search import Network # for random search
-from datasets import load_dataset, DSET_NAME_TBL, BATCH_SIZE_TBL
+from datasets import load_dataset, DSET_NAME_TBL
 from genotypes import GENOTYPE_TBL
 from sklearn.metrics import r2_score
 
 parser = argparse.ArgumentParser("darts")
 parser.add_argument('--dataset', type=str, default='cifar', help='name of the dataset to use (e.g. cifar, mnist, graphene)')
 parser.add_argument('--data', type=str, default='../data', help='location of the data corpus')
-parser.add_argument('--batch_size', type=int, default=0, 
-                    help='batch size; default of 0 looks up defaults per data set in datasets.py BATCH_SIZE_TBL')
+parser.add_argument('--val_portion', type=float, default=0.1, help='portion of validation data')
+parser.add_argument('--batch_size', type=int, default=64, help='batch size')
 parser.add_argument('--optimizer', type=str, default='Adam', help='optimizer; one of SGD or Adam')
 parser.add_argument('--learning_rate', type=float, default=0.001, help='init learning rate')
 parser.add_argument('--momentum', type=float, default=0.9, help='momentum')
@@ -44,6 +44,8 @@ parser.add_argument('--save', type=str, default='EXP', help='experiment name')
 parser.add_argument('--seed', type=int, default=0, help='random seed')
 parser.add_argument('--arch', type=str, default='DATASET', 
                     help='which architecture to use; default is lookup by dataset name')
+parser.add_argument('--fc1_size', type=int, default=1024, help='number of units in fully connected layer 1')
+parser.add_argument('--fc2_size', type=int, default=1024, help='number of units in fully connected layer 2')
 parser.add_argument('--grad_clip', type=float, default=5, help='gradient clipping')
 parser.add_argument('--random', action="store_true", default=False, help='train a random cell')
 args = parser.parse_args()
@@ -83,7 +85,9 @@ def main():
   logging.info("args = %s", args)
 
   train_data, OUTPUT_DIM, IN_CHANNELS, is_regression = load_dataset(args, train=True)
-  valid_data, _, _, _ = load_dataset(args, train=False)
+
+  # train_data, OUTPUT_DIM, IN_CHANNELS, is_regression = load_dataset(args, train=True)
+  # valid_data, _, _, _ = load_dataset(args, train=False)
 
   criterion = nn.CrossEntropyLoss() if not is_regression else nn.MSELoss()
 
@@ -107,7 +111,7 @@ def main():
   # Set the inference network; default is NetworkCifar10; supported alternatives NetworkGalaxyZoo
   if dataset == 'GalaxyZoo':
     model = NetworkGalaxyZoo(C=args.init_channels, num_classes=OUTPUT_DIM, layers=args.layers, genotype=genotype, 
-                             fc1_size=1024, fc2_size=1024, num_channels=IN_CHANNELS)
+                             fc1_size=args.fc1_size, fc2_size=args.fc2_size, num_channels=IN_CHANNELS)
   else:
     model = NetworkCIFAR(args.init_channels, OUTPUT_DIM, args.layers, args.auxiliary, genotype, num_channels=IN_CHANNELS)
   model = model.cuda()
@@ -132,33 +136,58 @@ def main():
   else:
     raise ValueError(f"Bad optimizer; got {args.optimizer}, must be one of 'SGD' or 'Adam'.")
 
-  # If batch size was not input manually, look up default batch size for this data set
-  if args.batch_size > 0:
-    batch_size = args.batch_size
-    # print(f'Using input batch_size = {batch_size}')
-  else:
-    batch_size = BATCH_SIZE_TBL[dataset]
-    print(f'Using default batch_size = {batch_size}')
+  # train_queue = torch.utils.data.DataLoader(
+      # train_data, batch_size=batch_size, shuffle=True, pin_memory=True, num_workers=2)
+
+  # valid_queue = torch.utils.data.DataLoader(
+      # valid_data, batch_size=batch_size, shuffle=False, pin_memory=True, num_workers=2)
+
+  # Split training data into training and validation queues
+  # Can't use test set for validation on GalaxyZoo because test labels unavailable (can only upload to Kaggle)
+  num_train = len(train_data)
+  indices = list(range(num_train))
+  train_portion = 1.0 - args.val_portion
+  split = int(np.floor(train_portion * num_train))
 
   train_queue = torch.utils.data.DataLoader(
-      train_data, batch_size=batch_size, shuffle=True, pin_memory=True, num_workers=2)
+      train_data, batch_size=args.batch_size,
+      sampler=torch.utils.data.sampler.SubsetRandomSampler(indices[:split]),
+      pin_memory=True, num_workers=2)
 
   valid_queue = torch.utils.data.DataLoader(
-      valid_data, batch_size=batch_size, shuffle=False, pin_memory=True, num_workers=2)
+      train_data, batch_size=args.batch_size,
+      sampler=torch.utils.data.sampler.SubsetRandomSampler(indices[split:num_train]),
+      pin_memory=True, num_workers=2)
 
-  scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, float(args.epochs))
+  # scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, float(args.epochs))
+
+  # history of training and validation loss; 2 columns for loss and accuracy / R2
+  hist_trn = np.zeros((args.epochs, 2))
+  hist_val = np.zeros((args.epochs, 2))
+  metric_name = 'accuracy' if not is_regression else 'R2'
 
   for epoch in range(args.epochs):
-    scheduler.step()
-    logging.info('epoch %d lr %e', epoch, scheduler.get_lr()[0])
-    model.drop_path_prob = args.drop_path_prob * epoch / args.epochs
+    # scheduler.step()
+    # logging.info('epoch %d lr %e', epoch, scheduler.get_lr()[0])
+    logging.info('epoch %d lr %e', epoch, args.learning_rate)
+    # model.drop_path_prob = args.drop_path_prob * epoch / args.epochs
+    model.drop_path_prob = args.drop_path_prob
 
+    # training results
     train_acc, train_obj = train(train_queue, model, criterion, optimizer, is_regression=is_regression)
-    logging.info('train_acc (R^2 for regression) %f', train_acc)
+    logging.info(f'training loss; {metric_name}: {train_obj:e} {train_acc:f}')
+    # save history to numpy arrays
+    hist_trn[epoch] = [train_acc, train_obj]
+    np.save(os.path.join(args.save, 'hist_trn'), hist_trn)
 
+    # validation results
     valid_acc, valid_obj = infer(valid_queue, model, criterion, is_regression=is_regression)
-    logging.info('valid_acc (R^2 for regression) %f', valid_acc)
+    logging.info(f'validation loss; {metric_name}: {valid_obj:e} {valid_acc:f}')
+    # save history to numpy arrays
+    hist_val[epoch] = [valid_acc, valid_obj]
+    np.save(os.path.join(args.save, 'hist_val'), hist_val)
 
+    # save current model weights
     utils.save(model, os.path.join(args.save, 'weights.pt'))
 
 

--- a/cnn/train_search.py
+++ b/cnn/train_search.py
@@ -129,11 +129,11 @@ def main():
 
     # training
     train_acc, train_obj = train(train_queue, valid_queue, model, architect, criterion, optimizer, lr, is_regression=is_regression)
-    logging.info('train_acc (R^2 for regression) %f', train_acc)
+    logging.info('training loss; accuracy or R2: %e %f', train_obj, train_acc)
 
     # validation
     valid_acc, valid_obj = infer(valid_queue, model, criterion, is_regression=is_regression)
-    logging.info('valid_acc (R^2 for regression) %f', valid_acc)
+    logging.info('validation loss; accuracy or R2: %e %f', valid_obj, valid_acc)
 
     utils.save(model, os.path.join(args.save, 'weights.pt'))
 

--- a/cnn/train_search.py
+++ b/cnn/train_search.py
@@ -44,6 +44,8 @@ parser.add_argument('--train_portion', type=float, default=0.5, help='portion of
 parser.add_argument('--unrolled', action='store_true', default=True, help='use one-step unrolled validation loss')
 parser.add_argument('--arch_learning_rate', type=float, default=3e-4, help='learning rate for arch encoding')
 parser.add_argument('--arch_weight_decay', type=float, default=1e-3, help='weight decay for arch encoding')
+parser.add_argument('--gz_regression', action='store_true', default=False, 
+                    help='run GalaxyZoo as a standard regression (default True follows custom GZ decision tree)')
 args = parser.parse_args()
 
 args.save = 'search-{}-{}'.format(args.save, time.strftime("%Y%m%d-%H%M%S"))
@@ -57,8 +59,9 @@ fh.setFormatter(logging.Formatter(log_format))
 logging.getLogger().addHandler(fh)
 
 # In the special case that the dataset is GalaxyZoo, overwrite Network with GalaxyZooNetwork
-# if args.dataset in VALID_DSET_NAMES['GalaxyZoo']:
-#    Network = NetworkGalaxyZoo
+# unless the user specified gz_regression
+if (args.dataset in VALID_DSET_NAMES['GalaxyZoo']) and not args.gz_regression:
+   Network = NetworkGalaxyZoo
 
 def main():
   if not torch.cuda.is_available():

--- a/cnn/train_search.py
+++ b/cnn/train_search.py
@@ -24,7 +24,7 @@ parser = argparse.ArgumentParser("darts")
 parser.add_argument('--dataset', type=str, default='cifar', help='name of the dataset to use (e.g. cifar, mnist, graphene)')
 parser.add_argument('--data', type=str, default='../data', help='location of the data corpus')
 parser.add_argument('--batch_size', type=int, default=64, help='batch size')
-parser.add_argument('--optimizer', type=str, default='SGD', help='optimizer; one of SGD or Adam')
+parser.add_argument('--optimizer', type=str, default='Adam', help='optimizer; one of SGD or Adam')
 parser.add_argument('--primitives', type=str, default='Default', 
                     help='set of primitive operations for arch search; defined in genotypes.py')
 parser.add_argument('--learning_rate', type=float, default=0.001, help='init learning rate')


### PR DESCRIPTION
Changes made to support training Galaxy Zoo data set.

datasets.py: for GalaxyZoo data set, need to manually split training samples into train (90%) and validation (10%). This is because the test set for GalaxyZoo doesn't include ground truth labels.

genotypes.py: added the most recent architecture for GalaxyZoo found 2019-11-05.

model.py: created a new NetworkGalaxyZoo class.  This is analogous to the NetworkGalaxyZoo class  model_search.py that extends Network in model_search.py.  It contains two fully connected layers and the GalaxyZoo decision tree.

model_search.py: Changed Cell class so primitives is no longer a global constant, but an input argument passed by string name. This allows us to run architecture searches on different datasets with different sets of primitives.  This change was necessary to support including the 2x2 max pool operation in the architecture search (2x2 max pool was used multiple times in the winning entry.)  This change also rippled through to Network and NetworkGalaxyZoo.  Primitives are now stored on a table keyed by primitive_name (a string) with value a list of operation names.  The NetworkGalaxyZoo class has a similar interface to Network, with fully connected layers and the GZ decision tree at the end.

operations.py: Added max_pool_2x2 operation.  This required asymmetric padding so the size would remain the same.

train.py: Added new command line arguments to support GalaxyZoo.  These can be ignored when not training GZ.  Architecture will now default to a lookup table keyed by dataset name.  Can still manually name the architecture with the --arch flag the old way.  Added Adam optimizer; this is now the default with a LR of 1.0E-3.  Logging now includes the MSE (R2 is incorrect for GZ, so this is essential to monitor progress in training.)  Training results are saved to numpy arrays so we don't need to strip log files.  (This is also true for train_search.py)

train_search.py: Added NetworkGalaxyZoo class.  Extends Network API with FC layers and GZ decision tree.  Changed default weight decay to 1.0E-6 b/c 3.0E-4 looked very high.  Added Adam optimizer. This is now the default with LR=1.0E-3.  Can specify desired primities with --primitives argument.

utils.py: Added data transforms for 